### PR TITLE
Bump log4j-api from 2.5 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.5</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Bumps log4j-api from 2.5 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api dependency-type: direct:production ...